### PR TITLE
Apply snippet bugfix

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2012-2014 Vojtěch Dobeš
  * @license MIT
  *
- * @version 2.5.0
+ * @version 2.5.1
  */
 
 (function(window, $, undefined) {
@@ -551,6 +551,9 @@
 			return $('#' + this.escapeSelector(id));
 		},
 		applySnippet: function ($el, html, back, perRequestAppend, perRequestPrepend) {
+			if ($el.length === 0) {
+				return;
+			}
 			if (!back && ($el.is('[data-ajax-append]') || perRequestAppend.indexOf($el[0].id) > -1)) {
 				$el.append(html);
 			} else if (!back && ($el.is('[data-ajax-prepend]') || perRequestPrepend.indexOf($el[0].id) > -1)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nette.ajax.js",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Flexible utility script for AJAX in Nette Framework. Supports snippets, redirects etc. http://addons.nette.org/cs/nette-ajax-js",
   "main": "nette.ajax.js",
   "repository": {


### PR DESCRIPTION
`applySnippet` can receive empty jQuery object `$el` and in that case, we cannot access `$el[0].id`. When empty object received, we don't need to do anything in `applySnippet`, so we just return.