### PR TITLE
Add jQuery 4 compatibility, bump to 2.6.0

### DIFF
--- a/extensions/scrollTo.ajax.js
+++ b/extensions/scrollTo.ajax.js
@@ -5,13 +5,13 @@
  */
 $.nette.ext('scrollTo', {
 	init: function () {
-		this.ext('snippets', true).before($.proxy(function ($el) {
+		this.ext('snippets', true).before((function ($el) {
 			if (this.shouldTry && !$el.is('title')) {
 				var offset = $el.offset();
 				scrollTo(offset.left, offset.top);
 				this.shouldTry = false;
 			}
-		}, this));
+		}).bind(this));
 	},
 	success: function (payload) {
 		this.shouldTry = true;

--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2012-2014 Vojtěch Dobeš
  * @license MIT
  *
- * @version 2.5.1
+ * @version 2.6.0
  */
 
 (function(window, $, undefined) {
@@ -184,7 +184,7 @@
 		 * @return {xhr|null}
 		 */
 		this.ajax = function (settings, ui, e) {
-			if ($.type(settings) === 'string') {
+			if (typeof settings === 'string') {
 				settings = {url: settings};
 			}
 			if (!settings.nette && ui && e) {
@@ -225,7 +225,7 @@
 					}
 					if (typeof settings.off === 'string') settings.off = [settings.off];
 					settings.off = $.grep($.each(settings.off, function (off) {
-						return $.trim(off);
+						return off.trim();
 					}), function (off) {
 						return off.length;
 					});
@@ -603,13 +603,13 @@
 	// option to abort by ESC (thx to @vrana)
 	$.nette.ext('abort', {
 		init: function () {
-			$('body').keydown($.proxy(function (e) {
+			$('body').keydown((function (e) {
 				if (this.xhr && (e.keyCode.toString() === '27' // Esc
 					&& !(e.ctrlKey || e.shiftKey || e.altKey || e.metaKey))
 				) {
 					this.xhr.abort();
 				}
-			}, this));
+			}).bind(this));
 		},
 		start: function (xhr) {
 			this.xhr = xhr;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nette.ajax.js",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Flexible utility script for AJAX in Nette Framework. Supports snippets, redirects etc. http://addons.nette.org/cs/nette-ajax-js",
   "main": "nette.ajax.js",
   "repository": {


### PR DESCRIPTION
Replace removed jQuery 4 APIs with native equivalents:
- $.type() → typeof
- $.trim() → String.prototype.trim()
- $.proxy() → Function.prototype.bind() (nette.ajax.js + scrollTo extension)

All changes are backward compatible with jQuery 3.