### PR TITLE
Fix `off.trim is not a function` under jQuery 4

### DIFF
--- a/nette.ajax.js
+++ b/nette.ajax.js
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2012-2014 Vojtěch Dobeš
  * @license MIT
  *
- * @version 2.6.0
+ * @version 2.6.1
  */
 
 (function(window, $, undefined) {
@@ -224,9 +224,9 @@
 						settings.off = rawOff;
 					}
 					if (typeof settings.off === 'string') settings.off = [settings.off];
-					settings.off = $.grep($.each(settings.off, function (off) {
+					settings.off = settings.off.map(function (off) {
 						return off.trim();
-					}), function (off) {
+					}).filter(function (off) {
 						return off.length;
 					});
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nette.ajax.js",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Flexible utility script for AJAX in Nette Framework. Supports snippets, redirects etc. http://addons.nette.org/cs/nette-ajax-js",
   "main": "nette.ajax.js",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 2.6.0 (PR #7): under jQuery 4, the first `data-ajax-off` driven AJAX call crashes with:

```
Uncaught TypeError: t.trim is not a function
```

## Root cause

The offending code at `nette.ajax.js:227–231`:

```js
settings.off = $.grep($.each(settings.off, function (off) {
    return off.trim();
}), function (off) {
    return off.length;
});
```

Two layered bugs:

1. **`$.each(array, callback)` invokes the callback with `(index, value)`** — so `off` was always an **index** (Number), never a string. In jQuery 3, `$.trim(number)` silently coerced the number to a string, so it never threw; in jQuery 4, `(0).trim()` raises `TypeError` because `Number.prototype.trim` doesn't exist.
2. **`$.each` returns the original array unchanged** — it's an iterator, not `map`, and the callback's return value is discarded. So even in jQuery 3 the trim step **never actually ran**, and `$.grep` filtered untrimmed values. This was a pre-existing silent bug that the jQuery 4 change happened to expose.

## Fix

Replace with `Array.prototype.map().filter()`:

```js
settings.off = settings.off.map(function (off) {
    return off.trim();
}).filter(function (off) {
    return off.length;
});
```

At that point `settings.off` is guaranteed to be an array (line 226 wraps strings), so the native methods are safe. This also fixes the pre-existing bug — trim now actually takes effect.

## Version

Patch bump to **2.6.1**.

## Test plan

Verified all four `data-ajax-off` parsing branches (lines 217–225) in the browser:

- [x] `data-ajax-off="snippets, redirect"` (comma + whitespace) — yields `["snippets", "redirect"]`
- [x] `data-ajax-off="snippets redirect"` (space-separated) — yields `["snippets", "redirect"]`
- [x] `data-ajax-off="snippets  redirect"` (double space) — yields `["snippets", "redirect"]`
- [x] `data-ajax-off="snippets"` (single) — yields `["snippets"]`
- [x] Regression test against jQuery 3
- [x] Smoke test of AJAX calls without `data-ajax-off`

The JSON-array form of `data-ajax-off` (starting with `[`) remains out of scope — if the parsed array contains non-strings, `off.trim()` would still throw, but that's a pre-existing limitation unrelated to this regression.